### PR TITLE
ci: fix clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,22 +37,14 @@ jobs:
         command: test
         args: --no-default-features --lib --examples --tests --verbose
 
-    - name: bench
+    - name: build benchmarks
       uses: actions-rs/cargo@v1
       with:
         command: test
         args: --benches --no-run --verbose
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- -D warnings
+    - name: clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all-features


### PR DESCRIPTION
Fixes [CI failures](https://github.com/domodwyer/anchorhash/actions/runs/3435796221/jobs/5739596360) caused by the clippy-check action.

---

* ci: fix clippy lints (9b3a9f8)

      Run "cargo clippy" directly, rather than rely on the clippy action due
      to:
      
          https://github.com/actions-rs/clippy-check/issues/167