### PR TITLE
Add a remap designation

### DIFF
--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -4,6 +4,7 @@ use crate::fasthash;
 
 use super::range_map;
 
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Bucket {
     Original(u16),
     Remapped(u16)
@@ -298,6 +299,26 @@ mod tests {
         if a.add_bucket().is_some() {
             panic!("adding bucket to full anchor should fail");
         }
+    }
+
+    #[test]
+    fn test_remap_bucket() {
+        const SIZE: u16 = 20;
+        let mut a = Anchor::new(SIZE, SIZE - 1);
+
+        // 0 should map to 0
+        let bucket = a.get_bucket(0);
+        assert_eq!(bucket, Bucket::Original(0));
+
+        // when zero is removed it should remap to 18
+        a.remove_bucket(0);
+        let bucket = a.get_bucket(0);
+        assert_eq!(bucket, Bucket::Remapped(18));
+
+        // when zero is added back it should remap to 0
+        a.add_bucket();
+        let bucket = a.get_bucket(0);
+        assert_eq!(bucket, Bucket::Original(0));
     }
 
     #[quickcheck]

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -7,7 +7,7 @@ use super::range_map;
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Bucket {
     Original(u16),
-    Remapped(u16)
+    Remapped(u16),
 }
 
 impl Deref for Bucket {
@@ -16,7 +16,7 @@ impl Deref for Bucket {
     fn deref(&self) -> &Self::Target {
         match self {
             Bucket::Original(v) => v,
-            Bucket::Remapped(v) => v
+            Bucket::Remapped(v) => v,
         }
     }
 }

--- a/src/anchor.rs
+++ b/src/anchor.rs
@@ -1,6 +1,24 @@
+use std::ops::Deref;
+
 use crate::fasthash;
 
 use super::range_map;
+
+pub(crate) enum Bucket {
+    Original(u16),
+    Remapped(u16)
+}
+
+impl Deref for Bucket {
+    type Target = u16;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Bucket::Original(v) => v,
+            Bucket::Remapped(v) => v
+        }
+    }
+}
 
 /// Anchor is an implementation of Algorithm 3 from the AnchorHash paper.
 ///
@@ -83,9 +101,10 @@ impl Anchor {
     ///     b←h                         // b←H_W_b(k)
     ///   return b
     /// ```
-    pub(crate) fn get_bucket(&self, k: u32) -> u16 {
+    pub(crate) fn get_bucket(&self, k: u32) -> Bucket {
         // Map the (already hashed) key into the range [0, capacity)
         let mut b = range_map(k, self.capacity as u32) as usize;
+        let mut remapped = false;
 
         // While b is removed
         while self.A[b] > 0 {
@@ -100,6 +119,7 @@ impl Anchor {
 
             // Wb[h] != h (b removed prior to h)
             while self.A[h as usize] >= self.A[b] {
+                remapped = true;
                 // search for Wb[h]
                 h = self.K[h as usize] as _;
             }
@@ -107,8 +127,11 @@ impl Anchor {
             // b ← HWb(k)
             b = h as _;
         }
-
-        b as u16
+        if remapped {
+            Bucket::Remapped(b as _)
+        } else {
+            Bucket::Original(b as _)
+        }
     }
 
     /// Add a new bucket to the anchor.
@@ -303,7 +326,7 @@ mod tests {
 
             // Remove the bucket to drive the removal logic.
             if working.len() > 1 {
-                a.remove_bucket(got);
+                a.remove_bucket(*got);
                 assert!(working.remove(&got));
             }
         }
@@ -332,7 +355,7 @@ mod tests {
         for _ in 0..KEYS {
             let k = rng.gen();
             let got = a.get_bucket(k);
-            let counter = seen.entry(got).or_insert(0);
+            let counter = seen.entry(*got).or_insert(0);
             *counter += 1;
         }
 

--- a/src/anchor_hash.rs
+++ b/src/anchor_hash.rs
@@ -2,15 +2,20 @@ use std::{
     collections::hash_map::RandomState,
     convert::TryFrom,
     default::Default,
+    fmt,
     hash::{BuildHasher, Hash, Hasher},
     iter::FromIterator,
     marker::PhantomData,
+    ops::Deref,
 };
 
 use hashbrown::HashMap;
 use thiserror::Error;
 
-use crate::{anchor::Anchor, ResourceIterator, ResourceMutIterator};
+use crate::{
+    anchor::{Anchor, Bucket},
+    ResourceIterator, ResourceMutIterator,
+};
 
 /// Errors returned when operating on an [`AnchorHash`] instance.
 #[derive(Debug, Error, PartialEq, Eq, Clone, Copy)]
@@ -26,6 +31,35 @@ pub enum Error {
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// This indicates if anchorhash returned a resource that didn't require and remapping.
+#[derive(Debug, PartialEq)]
+pub enum Resource<R> {
+    /// The resource was returned as it was found in the original bucket.
+    Original(R),
+    /// The resource was rehashed to a new bucket.
+    Rehashed(R),
+}
+
+impl<T> Deref for Resource<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Resource::Original(v) => v,
+            Resource::Rehashed(v) => v,
+        }
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Resource<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Resource::Original(v) => write!(f, "{}", v),
+            Resource::Rehashed(v) => write!(f, "{}", v),
+        }
+    }
+}
 
 /// Initialise a new [`AnchorHash`] instance.
 ///
@@ -289,7 +323,7 @@ where
     /// Consistently hash `key` to a configured resource.
     ///
     /// This method will return [`None`] when `self` contains no resources.
-    pub fn get_resource(&self, key: K) -> Option<&R> {
+    pub fn get_resource(&self, key: K) -> Option<Resource<&R>> {
         // Hash the key to a u32 value
         let mut hasher = self.hasher.build_hasher();
         key.hash(&mut hasher);
@@ -299,7 +333,14 @@ where
         let b = self.anchor.get_bucket(key as u32);
 
         // Resolve the bucket -> resource indirection
-        self.resources.get(&*b)
+        let resource = self.resources.get(&*b);
+        match resource {
+            Some(r) => match b {
+                Bucket::Original(_) => Some(Resource::Original(r)),
+                Bucket::Remapped(_) => Some(Resource::Rehashed(r)),
+            },
+            None => None,
+        }
     }
 
     /// Add `resource`, allowing keys to map to it.
@@ -389,7 +430,7 @@ mod tests {
         a.add_resource(24).expect("should add new resource");
 
         // And now the key maps to the only bucket
-        assert_eq!(a.get_resource(42), Some(&24));
+        assert_eq!(a.get_resource(42), Some(Resource::Original(&24)));
 
         a.remove_resource(&24).expect("should remove resource");
 
@@ -435,13 +476,13 @@ mod tests {
         a.add_resource(&server_b).unwrap();
 
         // Ensure the key maps to one of the two servers
-        let got = a.get_resource("a key").expect("should return a resource");
+        let got = *a.get_resource("a key").expect("should return a resource");
         assert!(got == &&server_a || got == &&server_b);
 
         // Remove server B and ensure the key maps to server A
         a.remove_resource(&&server_b)
             .expect("removing existing resource should succeed");
-        let got = a.get_resource("a key").expect("should return a resource");
+        let got = *a.get_resource("a key").expect("should return a resource");
         assert_eq!(got, &&server_a);
     }
 
@@ -456,13 +497,13 @@ mod tests {
         a.add_resource(&server_b).unwrap();
 
         // Ensure the key maps to one of the two servers
-        let got = a.get_resource("a key").expect("should return a resource");
+        let got = *a.get_resource("a key").expect("should return a resource");
         assert!(got == &&server_a || got == &&server_b);
 
         // Remove server B and ensure the key maps to server A
         a.remove_resource(&&server_b)
             .expect("removing existing resource should succeed");
-        let got = a.get_resource("a key").expect("should return a resource");
+        let got = *a.get_resource("a key").expect("should return a resource");
         assert_eq!(got, &&server_a);
     }
 

--- a/src/anchor_hash.rs
+++ b/src/anchor_hash.rs
@@ -299,7 +299,7 @@ where
         let b = self.anchor.get_bucket(key as u32);
 
         // Resolve the bucket -> resource indirection
-        self.resources.get(&b)
+        self.resources.get(&*b)
     }
 
     /// Add `resource`, allowing keys to map to it.


### PR DESCRIPTION
This PR gives the library the ability to indicate to the caller if the bucket being returned is remapped. This will allow the caller to make decisions about how to utilize the bucket. 